### PR TITLE
Set the user agent acording to the "Tile Usage Policy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Use `https://yourdomain.com/appfolder/https://tileserver.com/{zoom}/{x}/{y}.png`
 
 Add other tile server by extending the $domains array.
 
+Set the user agent acording to the [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/).
+
+```php
+# index.php line 70
+$agent = '<USER AGENT STRING>';
+```
+
 ### leaflet Example
 ```
 var tile_osm = L.tileLayer('https://yourdomain.com/appfolder/https://http://{s}.tile.openstreetmap.org/{zoom}/{x}/{y}.png', {

--- a/index.php
+++ b/index.php
@@ -8,6 +8,7 @@ $cacheHeaderTime = 60*60*24*365; // Browser Header (sec)
 $cacheFileTime = 60*60*24*356 / 4; // max File Age (sec)
 
 $domains = array(
+	"tile.openstreetmap.org" => "osm",
 	"a.tile.openstreetmap.org" => "osm",
 	"b.tile.openstreetmap.org" => "osm",
 	"c.tile.openstreetmap.org" => "osm",
@@ -65,9 +66,12 @@ function cacheTile($tileURL, $cacheTileFile) {
     mkdir(dirname($cacheTileFile), 0777, true);
   }
 
+  // TODO SET THE USERAGENT STRING AND
+  // $agent = '<USER AGENT STRING>';
   $ch = curl_init($tileURL);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
   curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+  curl_setopt($ch, CURLOPT_USERAGENT, $agent);
 
 
   $data = curl_exec($ch);


### PR DESCRIPTION
Due to the missing user agent, the osm tile servers reject requests from this script. See [Tile Usage Policy](https://operations.osmfoundation.org/policies/tiles/)